### PR TITLE
Add missing `~` symbol to messages with negated bitmasks.

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -247,7 +247,7 @@ pub fn decode(instruction : &str) -> Option<String> {
 		} else if shift_amount == 0 {
 			result += format!("{} = {} & {:#X};\n", r_dest, r_source, bitmask).as_str();
 			result += "Could also be:\n";
-			result += format!("{} = {} & {:#X};\n", r_dest, r_source, !bitmask).as_str();
+			result += format!("{} = {} & ~{:#X};\n", r_dest, r_source, !bitmask).as_str();
 		} else {
 		  /* mwcc sometimes does an optimization where n*2^m will become rlwinm, where the zero bits are ensured to be 0
 		  through anding with a bitmask (for example, n*4 becomes n<<2 & ~0x3, clearing the lower bits */
@@ -263,7 +263,7 @@ pub fn decode(instruction : &str) -> Option<String> {
 		  }else{
 			result += format!("{} = ({} << {}) & {:#X};\n", r_dest, r_source, shift_amount, bitmask).as_str();
 			result += "Could also be:\n";
-			result += format!("{} = ({} << {}) & {:#X};\n", r_dest, r_source, shift_amount, !bitmask).as_str();
+			result += format!("{} = ({} << {}) & ~{:#X};\n", r_dest, r_source, shift_amount, !bitmask).as_str();
 			//right shift then and is sometimes optimized into rlwinm
 			result += format!("{} = ({} >> {}) & {:#X};\n", r_dest, r_source, (32 - shift_amount), bitmask).as_str();
 			//result += format!(r_dest + " = (rotl(" + r_source + ", " + shift_amount + ")) & 0x" + NumberToHexString(bitmask) + ";").as_str();


### PR DESCRIPTION
I noticed a small deficiency with the rlwinm decoder tooltip in objdiff recently. Here's an example screenshot.
![image](https://github.com/user-attachments/assets/1caad4bf-5234-49c4-afd6-a52d81089004)
I noticed that the "could also be" message should have used `~0x1f` rather than `0x1f`.

After applying my patch we get this output.
![image](https://github.com/user-attachments/assets/52f8eb7e-b57a-4cba-b394-809812a7cb28)

Unfortunately I don't know off-hand of an example of the second change here so you may want to test that further. It makes sense to me though that it should be negated as well.